### PR TITLE
Fix code scanning alert no. 1: Server-side request forgery

### DIFF
--- a/pages/api/translate.ts
+++ b/pages/api/translate.ts
@@ -308,6 +308,16 @@ const translateWithSiliconFlow = async (text: string, source: string, target: st
 
 // 渠道: 自定义API
 const translateWithCustomAPI = async (text: string, source: string, target: string, customAPI: any): Promise<string> => {
+  const allowedEndpoints = [
+    "https://api.example1.com/translate",
+    "https://api.example2.com/translate"
+    // Add other allowed endpoints here
+  ];
+
+  if (!allowedEndpoints.includes(customAPI.endpoint)) {
+    throw new Error("未授权的API端点");
+  }
+
   const data = {
     model: customAPI.model,
     messages: [


### PR DESCRIPTION
Fixes [https://github.com/KintaMiao/simplelmt/security/code-scanning/1](https://github.com/KintaMiao/simplelmt/security/code-scanning/1)

To fix the problem, we need to ensure that the `customAPI.endpoint` is validated against a list of allowed endpoints or domains. This can be achieved by maintaining an allow-list of valid endpoints and checking the user-provided endpoint against this list before making the request. This approach ensures that only pre-approved endpoints can be used, mitigating the risk of SSRF attacks.

1. Create an allow-list of valid endpoints.
2. Validate the `customAPI.endpoint` against this allow-list before making the request.
3. If the endpoint is not in the allow-list, throw an error.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
